### PR TITLE
Improve setup

### DIFF
--- a/pyOTDR.py
+++ b/pyOTDR.py
@@ -1,1 +1,0 @@
-pyOTDR/main.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,10 @@
 [bdist_wheel]
 universal=1
+
+[mypy]
+mypy_path = stubs
+ignore_missing_imports = True
+
+[options.entry_points]
+console_scripts =
+    pyOTDR=pyOTDR.main:main


### PR DESCRIPTION
I removed the link. All you have to do now is to `pip install pyOTDR`
and the binary will go in the `bin` repo of you python install (global
or virtualenv).